### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 ## `gcr.io/paketo-buildpacks/puma`
 
-The Puma CNB sets the start command for a given ruby application that runs on a
-[puma server](https://puma.io).
+The Puma CNB sets the start command for a given ruby application that runs on a [puma server](https://puma.io).
 
 ## Integration
 
-This CNB writes a start command, so there's currently no scenario we can imagine
-that you would need to require it as dependency. If a user likes to include some
-other functionality, it can be done independent of the Puma CNB without
-requiring a dependency of it.
+This CNB writes a start command, so there's currently no scenario we can
+imagine that you would need to require it as dependency. If a user likes to
+include some other functionality, it can be done independent of the Puma CNB
+without requiring a dependency of it.
 
 ## Packaging
 
@@ -25,9 +24,7 @@ For example:
 ./scripts/package.sh --version 0.4.60
 ```
 
-This will build the buildpack for all target architectures specified in
-`buildpack.toml` (amd64 and arm64 by default) and create architecture-specific
-buildpackages in the `build/` directory.
+This will build the buildpack for all target architectures specified in `buildpack.toml` (amd64 and arm64 by default) and create architecture-specific buildpackages in the `build/` directory.
 
 ## Publishing
 
@@ -54,8 +51,7 @@ For example:
 The script will automatically:
 - Read target architectures from `buildpack.toml`
 - Extract the buildpack archive
-- Publish each architecture separately with arch-suffixed tags (e.g.,
-  `puma:0.4.60-amd64`, `puma:0.4.60-arm64`)
+- Publish each architecture separately with arch-suffixed tags (e.g., `puma:0.4.60-amd64`, `puma:0.4.60-arm64`)
 - Create and push a multi-arch manifest list
 
 ## `buildpack.yml` Configurations


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
